### PR TITLE
Wait for two days before suggesting new dependency versions

### DIFF
--- a/default.json
+++ b/default.json
@@ -4,6 +4,7 @@
     "github>openalcoholics/renovate-config:pub"
   ],
   "prHourlyLimit": 0,
+  "stabilityDays": 2,
   "automergeStrategy": "rebase",
   "packageRules": [
     {


### PR DESCRIPTION
We run into the issue of updates being suggested for releases which have not 100% gone through yet. I've seen that for Saufautomobil, where two packages need to be updated in tandem, but only one has been updated yet, and for some Java/Kotlin projects, where releases were announced before Maven Central availability.